### PR TITLE
Fix refresh counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,9 @@ $ make zexdoc
 * [MSX JAPAN/ファイル形式](https://msxjpn.jimdofree.com/%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E5%BD%A2%E5%BC%8F/)
 
 * [Yet Another Z80 Emulator by AG](http://www.mathematik.uni-ulm.de/users/ag/yaze-ag/)
+
+* [8ビット CPU Z80タイミング](http://www.yamamo10.jp/yamamoto/comp/Z80/Z80_Timming/index.php)
+
+* [Z80のRレジスタについて](https://electrelic.com/electrelic/node/1506)
+
+* [Visual Z80 Remix](https://floooh.github.io/visualz80remix/)

--- a/cmd/zexdoc/zexdoc.go
+++ b/cmd/zexdoc/zexdoc.go
@@ -49,6 +49,7 @@ func runZexdoc(name string) error {
 		IO:     io,
 	}
 
+	var stopProf = func() {}
 	if cpuprof != "" {
 		f, err := os.Create(cpuprof)
 		if err != nil {
@@ -58,7 +59,9 @@ func runZexdoc(name string) error {
 		if err := pprof.StartCPUProfile(f); err != nil {
 			return fmt.Errorf("could not start CPU profile: %w", err)
 		}
-		defer pprof.StopCPUProfile()
+		stopProf = func() {
+			pprof.StopCPUProfile()
+		}
 	}
 
 	for {
@@ -68,10 +71,13 @@ func runZexdoc(name string) error {
 				// TODO:
 				continue
 			}
+			stopProf()
 			return err
 		}
 		break
 	}
+
+	stopProf()
 
 	if memprof != "" {
 		f, err := os.Create(memprof)
@@ -85,7 +91,7 @@ func runZexdoc(name string) error {
 		}
 	}
 
-	if cpu.PC != 0xff04 {
+	if cpu.PC != 0xff03 {
 		return fmt.Errorf("halted on unexpected PC: %04x", cpu.PC)
 	}
 	return nil

--- a/cpu.go
+++ b/cpu.go
@@ -135,7 +135,7 @@ func (cpu *CPU) fetch16() uint16 {
 	return (uint16(h) << 8) | uint16(l)
 }
 
-// fetchM1 fetches a byte for M1 cycle
+// fetchM1 fetches a byte for M1 cycle.
 func (cpu *CPU) fetchM1() uint8 {
 	c := cpu.Memory.Get(cpu.PC)
 	cpu.PC++
@@ -143,19 +143,6 @@ func (cpu *CPU) fetchM1() uint8 {
 	rc := cpu.IR.Lo
 	cpu.IR.Lo = rc&0x80 | (rc+1)&0x7f
 	return c
-}
-
-// fetchM1x2 fetches two bytes for M1 cycle.
-// First one is a data, second one is a part of opcode.
-func (cpu *CPU) fetchM1x2() (d, c uint8) {
-	d = cpu.Memory.Get(cpu.PC)
-	cpu.PC++
-	c = cpu.Memory.Get(cpu.PC)
-	cpu.PC++
-	// increment refresh counter
-	rc := cpu.IR.Lo
-	cpu.IR.Lo = rc&0x80 | (rc+1)&0x7f
-	return d, c
 }
 
 func (cpu *CPU) ioIn(addr uint8) uint8 {

--- a/op_arith16_test.go
+++ b/op_arith16_test.go
@@ -71,10 +71,10 @@ func tADChlss(t *testing.T, r tReg, hl, ss uint16, c bool) {
 	postGPR.AF.Lo = flags
 	postSPR := preSPR
 	postSPR.PC = 0x0002
-	postSPR.IR = Register{Lo: 0x01}
+	postSPR.IR = Register{Lo: 0x02}
 
 	tSteps(t,
-		fmt.Sprintf("ADC HL %[1]s (HL=%04[2]x %[1]s=%04[3]x C=%[4]t", r.Label, hl, ss, c),
+		fmt.Sprintf("ADC HL %[1]s (HL=%04[2]x %[1]s=%04[3]x C=%[4]t)", r.Label, hl, ss, c),
 		States{GPR: preGPR, SPR: preSPR}, mem, 1,
 		States{GPR: postGPR, SPR: postSPR}, mem, maskDefault)
 }
@@ -153,10 +153,10 @@ func tSBChlss(t *testing.T, r tReg, hl, ss uint16, c bool) {
 	postGPR.AF.Lo = flags
 	postSPR := preSPR
 	postSPR.PC = 0x0002
-	postSPR.IR = Register{Lo: 0x01}
+	postSPR.IR = Register{Lo: 0x02}
 
 	tSteps(t,
-		fmt.Sprintf("SBC HL %[1]s (HL=%04[2]x %[1]s=%04[3]x C=%[4]t", r.Label, hl, ss, c),
+		fmt.Sprintf("SBC HL %[1]s (HL=%04[2]x %[1]s=%04[3]x C=%[4]t)", r.Label, hl, ss, c),
 		States{GPR: preGPR, SPR: preSPR}, mem, 1,
 		States{GPR: postGPR, SPR: postSPR}, mem, maskDefault)
 }

--- a/op_arith8_test.go
+++ b/op_arith8_test.go
@@ -491,7 +491,7 @@ func tADDAIXd(t *testing.T, av, dv uint8, ix uint16, mem MapMemory) {
 		}, mem, 1,
 		States{
 			GPR: postGPR,
-			SPR: SPR{IX: ix, PC: 0x0003, IR: Register{Lo: 0x01}},
+			SPR: SPR{IX: ix, PC: 0x0003, IR: Register{Lo: 0x02}},
 		}, mem, maskDefault)
 }
 
@@ -535,7 +535,7 @@ func tADDAIYd(t *testing.T, av, dv uint8, iy uint16, mem MapMemory) {
 		}, mem, 1,
 		States{
 			GPR: postGPR,
-			SPR: SPR{IY: iy, PC: 0x0003, IR: Register{Lo: 0x01}},
+			SPR: SPR{IY: iy, PC: 0x0003, IR: Register{Lo: 0x02}},
 		}, mem, maskDefault)
 }
 

--- a/op_bitop_test.go
+++ b/op_bitop_test.go
@@ -31,7 +31,7 @@ func TestBitop_BITbr(t *testing.T) {
 						1,
 						States{
 							GPR: wantGPR,
-							SPR: SPR{PC: 2, IR: Register{Lo: 0x01},
+							SPR: SPR{PC: 2, IR: Register{Lo: 0x02},
 								IX: 0x1000,
 							}},
 						mem.Clone(),
@@ -64,7 +64,7 @@ func TestBitop_BITbIXd(t *testing.T) {
 						1,
 						States{
 							GPR: GPR{AF: Register{Lo: flag}},
-							SPR: SPR{PC: 4, IR: Register{Lo: 0x01},
+							SPR: SPR{PC: 4, IR: Register{Lo: 0x03},
 								IX: 0x1000,
 							}},
 						mem.Clone(),
@@ -97,7 +97,7 @@ func TestBitop_BITbIYd(t *testing.T) {
 						1,
 						States{
 							GPR: GPR{AF: Register{Lo: flag}},
-							SPR: SPR{PC: 4, IR: Register{Lo: 0x01},
+							SPR: SPR{PC: 4, IR: Register{Lo: 0x03},
 								IY: 0x4180,
 							}},
 						mem.Clone(),
@@ -125,7 +125,7 @@ func TestBitop_SETbIXd(t *testing.T) {
 					States{GPR: GPR{}, SPR: SPR{IX: base}},
 					mem,
 					States{GPR: GPR{},
-						SPR: SPR{PC: 4, IR: Register{Lo: 0x01}, IX: base}},
+						SPR: SPR{PC: 4, IR: Register{Lo: 0x03}, IX: base}},
 					wantMem)
 			}
 		})
@@ -148,7 +148,7 @@ func TestBitop_SETbIYd(t *testing.T) {
 					States{GPR: GPR{}, SPR: SPR{IY: base}},
 					mem,
 					States{GPR: GPR{},
-						SPR: SPR{PC: 4, IR: Register{Lo: 0x01}, IY: base}},
+						SPR: SPR{PC: 4, IR: Register{Lo: 0x03}, IY: base}},
 					wantMem)
 			}
 		})
@@ -171,7 +171,7 @@ func TestBitop_RESbIXd(t *testing.T) {
 					States{GPR: GPR{}, SPR: SPR{IX: base}},
 					mem,
 					States{GPR: GPR{},
-						SPR: SPR{PC: 4, IR: Register{Lo: 0x01}, IX: base}},
+						SPR: SPR{PC: 4, IR: Register{Lo: 0x03}, IX: base}},
 					wantMem)
 			}
 		})
@@ -194,7 +194,7 @@ func TestBitop_RESbIYd(t *testing.T) {
 					States{GPR: GPR{}, SPR: SPR{IY: base}},
 					mem,
 					States{GPR: GPR{},
-						SPR: SPR{PC: 4, IR: Register{Lo: 0x01}, IY: base}},
+						SPR: SPR{PC: 4, IR: Register{Lo: 0x03}, IY: base}},
 					wantMem)
 			}
 		})

--- a/op_ctrl.go
+++ b/op_ctrl.go
@@ -40,6 +40,8 @@ func oopDAA(cpu *CPU) {
 }
 
 func oopHALT(cpu *CPU) {
+	// HALT does nothing. Since the program counter (PC) also does not advance, rewind it that was advanced by M1 fetch.
+	cpu.PC--
 	cpu.HALT = true
 }
 

--- a/operation.go
+++ b/operation.go
@@ -5,7 +5,7 @@ func (cpu *CPU) executeOne() {
 	if cpu.HALT {
 		return
 	}
-	switch c0 := cpu.fetch(); c0 {
+	switch c0 := cpu.fetchM1(); c0 {
 	case 0x00:
 		oopNOP(cpu)
 
@@ -602,7 +602,7 @@ func (cpu *CPU) executeOne() {
 		oopCPn(cpu)
 
 	case 0xcb:
-		switch c1 := cpu.fetch(); c1 {
+		switch c1 := cpu.fetchM1(); c1 {
 
 		// RLC r / RLC (HL)
 		case 0x00:
@@ -1185,7 +1185,7 @@ func (cpu *CPU) executeOne() {
 		}
 
 	case 0xdd:
-		switch c1 := cpu.fetch(); c1 {
+		switch c1 := cpu.fetchM1(); c1 {
 
 		// ADD IX, pp
 		case 0x09:
@@ -1540,7 +1540,7 @@ func (cpu *CPU) executeOne() {
 			oopLDSPIX(cpu)
 
 		case 0xcb:
-			switch d, c3 := cpu.fetch2(); c3 {
+			switch d, c3 := cpu.fetchM1x2(); c3 {
 
 			case 0x06:
 				oopRLCIXdP(cpu, d)
@@ -1628,7 +1628,7 @@ func (cpu *CPU) executeOne() {
 		}
 
 	case 0xed:
-		switch c1 := cpu.fetch(); c1 {
+		switch c1 := cpu.fetchM1(); c1 {
 
 		// IN r, (C)
 		// FIXME: IN r[6], (C) to apply flags only.
@@ -1792,7 +1792,7 @@ func (cpu *CPU) executeOne() {
 		}
 
 	case 0xfd:
-		switch c1 := cpu.fetch(); c1 {
+		switch c1 := cpu.fetchM1(); c1 {
 
 		// ADD IY, pp
 		case 0x09:
@@ -2147,7 +2147,7 @@ func (cpu *CPU) executeOne() {
 			oopLDSPIY(cpu)
 
 		case 0xcb:
-			switch d, c3 := cpu.fetch2(); c3 {
+			switch d, c3 := cpu.fetchM1x2(); c3 {
 
 			case 0x06:
 				oopRLCIYdP(cpu, d)

--- a/operation.go
+++ b/operation.go
@@ -2,9 +2,6 @@ package z80
 
 // executeOne executes only an op-code.
 func (cpu *CPU) executeOne() {
-	if cpu.HALT {
-		return
-	}
 	switch c0 := cpu.fetchM1(); c0 {
 	case 0x00:
 		oopNOP(cpu)

--- a/operation.go
+++ b/operation.go
@@ -1537,7 +1537,7 @@ func (cpu *CPU) executeOne() {
 			oopLDSPIX(cpu)
 
 		case 0xcb:
-			switch d, c3 := cpu.fetchM1x2(); c3 {
+			switch d, c3 := cpu.fetch(), cpu.fetchM1(); c3 {
 
 			case 0x06:
 				oopRLCIXdP(cpu, d)
@@ -2144,7 +2144,7 @@ func (cpu *CPU) executeOne() {
 			oopLDSPIY(cpu)
 
 		case 0xcb:
-			switch d, c3 := cpu.fetchM1x2(); c3 {
+			switch d, c3 := cpu.fetch(), cpu.fetchM1(); c3 {
 
 			case 0x06:
 				oopRLCIYdP(cpu, d)

--- a/z80_test.go
+++ b/z80_test.go
@@ -56,7 +56,7 @@ func tRunMinibios(t *testing.T, name, expOut string, breakpoints ...uint16) {
 		}
 		break
 	}
-	if cpu.PC != 0xff04 {
+	if cpu.PC != 0xff03 {
 		t.Errorf("halted on unexpected PC: %04x", cpu.PC)
 	}
 	if s := warnbuf.String(); s != "" {


### PR DESCRIPTION
Make the refresh counter (`R` register) behave like a real Z80.

* Increment `R` when fetch an opcode in M1 cycle
* Fix HALT behavior
    * Increment `R`
    * Keep program counter `PC`
* Stabilization of performance measurement with zexdoc

References:

* https://electrelic.com/electrelic/node/1506
* http://www.yamamo10.jp/yamamoto/comp/Z80/Z80_Timming/index.php
* https://floooh.github.io/visualz80remix/