### PR TITLE
Optimize Z80 CPU Emulation Performance

### DIFF
--- a/accum.go
+++ b/accum.go
@@ -2,7 +2,6 @@ package z80
 
 // This file includes functions which related to "accumulator" or "ACL"
 
-import "math/bits"
 
 func (cpu *CPU) updateFlagArith8(r, a, b uint16, subtract bool) {
 	c := r ^ a ^ b
@@ -22,29 +21,15 @@ func (cpu *CPU) updateFlagArith8(r, a, b uint16, subtract bool) {
 }
 
 func (cpu *CPU) updateFlagLogic8(r uint8, and bool) {
-	var nand uint8 = maskS53 | maskZ | maskH | maskPV | maskN | maskC
-	var or uint8
-	or |= r & maskS53
-	if r == 0 {
-		or |= maskZ
-	}
+	var or uint8 = sz53p[r]
 	if and {
 		or |= maskH
 	}
-	or |= (uint8(bits.OnesCount8(r)%2) - 1) & maskPV
-	cpu.AF.Lo = cpu.AF.Lo&^nand | or
+	cpu.AF.Lo = or
 }
 
 func (cpu *CPU) updateFlagBitop(r uint8, carry uint8) {
-	var nand uint8 = maskS53 | maskZ | maskH | maskPV | maskN | maskC
-	var or uint8
-	or |= r & maskS53
-	if r == 0 {
-		or |= maskZ
-	}
-	or |= (uint8(bits.OnesCount8(r)%2) - 1) & maskPV
-	or |= carry & maskC
-	cpu.AF.Lo = cpu.AF.Lo&^nand | or
+	cpu.AF.Lo = sz53p[r] | (carry & maskC)
 }
 
 func (cpu *CPU) addU8(a, b uint8) uint8 {

--- a/cpu.go
+++ b/cpu.go
@@ -3,7 +3,6 @@ package z80
 import (
 	"context"
 	"log"
-	"sync/atomic"
 )
 
 const (
@@ -170,32 +169,25 @@ func (cpu *CPU) ioOut(addr uint8, value uint8) {
 
 // Run executes instructions till HALT or error.
 func (cpu *CPU) Run(ctx context.Context) error {
-	var ctxErr error
-	var canceled int32
-	ctx2, cancel := context.WithCancel(ctx)
-	defer cancel()
-	go func() {
-		<-ctx2.Done()
-		ctxErr = ctx.Err()
-		atomic.StoreInt32(&canceled, 1)
-	}()
-
 	cpu.HALT = false
 	for {
-		if atomic.LoadInt32(&canceled) != 0 {
-			return ctxErr
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
 		}
-		cpu.Step()
-		if cpu.BreakPoints != nil {
-			if _, ok := cpu.BreakPoints[cpu.PC]; ok {
-				return ErrBreakPoint
+		for i := 0; i < 1000; i++ {
+			cpu.Step()
+			if cpu.BreakPoints != nil {
+				if _, ok := cpu.BreakPoints[cpu.PC]; ok {
+					return ErrBreakPoint
+				}
+			}
+			if cpu.HALT {
+				return nil
 			}
 		}
-		if cpu.HALT {
-			break
-		}
 	}
-	return nil
 }
 
 // Step executes an instruction.

--- a/tables.go
+++ b/tables.go
@@ -1,0 +1,19 @@
+package z80
+
+import "math/bits"
+
+var sz53p [256]uint8
+
+func init() {
+	for i := 0; i < 256; i++ {
+		v := uint8(i)
+		f := v & maskS53
+		if v == 0 {
+			f |= maskZ
+		}
+		if bits.OnesCount8(v)%2 == 0 {
+			f |= maskPV
+		}
+		sz53p[i] = f
+	}
+}


### PR DESCRIPTION
Optimized Z80 CPU emulation performance by implementing a lookup table for flags and batching instruction execution in the main loop. These changes significantly reduce the overhead of frequently executed operations and the execution loop itself.

---
*PR created automatically by Jules for task [9193934247443413781](https://jules.google.com/task/9193934247443413781) started by @koron*